### PR TITLE
Fix postgres placeholder handling

### DIFF
--- a/utils/dbox/clean.go
+++ b/utils/dbox/clean.go
@@ -52,7 +52,8 @@ func Clean(dbType, dsn string) {
 
 		_, err := os.Stat(path)
 		if os.IsNotExist(err) {
-			_, err := db.Exec("DELETE FROM migrations WHERE name = ?", name)
+			del := fmt.Sprintf("DELETE FROM migrations WHERE name = %s", placeholder(dbType, 1))
+			_, err := db.Exec(del, name)
 			if err != nil {
 				fmt.Println("Failed to delete migration record:", err)
 				os.Exit(1)

--- a/utils/dbox/helpers.go
+++ b/utils/dbox/helpers.go
@@ -1,0 +1,10 @@
+package dbox
+
+import "fmt"
+
+func placeholder(dbType string, n int) string {
+	if dbType == "postgres" {
+		return fmt.Sprintf("$%d", n)
+	}
+	return "?"
+}

--- a/utils/dbox/migrate.go
+++ b/utils/dbox/migrate.go
@@ -41,7 +41,8 @@ func Migrate(dbType, dsn string, pretend bool) {
 		migrationName := entry.Name()
 
 		var exists string
-		err := db.QueryRow("SELECT name FROM migrations WHERE name = ?", migrationName).Scan(&exists)
+		query := fmt.Sprintf("SELECT name FROM migrations WHERE name = %s", placeholder(dbType, 1))
+		err := db.QueryRow(query, migrationName).Scan(&exists)
 		if err != nil && err != sql.ErrNoRows {
 			fmt.Println("DB error:", err)
 			os.Exit(1)
@@ -70,7 +71,8 @@ func Migrate(dbType, dsn string, pretend bool) {
 			}
 		}
 
-		_, err = db.Exec("INSERT INTO migrations (name) VALUES (?)", migrationName)
+		insert := fmt.Sprintf("INSERT INTO migrations (name) VALUES (%s)", placeholder(dbType, 1))
+		_, err = db.Exec(insert, migrationName)
 		if err != nil {
 			fmt.Println("Failed to record migration:", migrationName)
 			os.Exit(1)

--- a/utils/dbox/refresh.go
+++ b/utils/dbox/refresh.go
@@ -46,7 +46,7 @@ func Refresh(dbType, dsn string, pretend bool) {
 	db.Close()
 
 	for _, name := range names {
-		db, err := sql.Open("sqlite", "db/database.sqlite")
+		db, err := sql.Open(dbType, dsn)
 		if err != nil {
 			fmt.Println("Failed to connect to DB:", err)
 			os.Exit(1)
@@ -67,7 +67,8 @@ func Refresh(dbType, dsn string, pretend bool) {
 			os.Exit(1)
 		}
 
-		_, err = db.Exec("DELETE FROM migrations WHERE name = ?", name)
+		del := fmt.Sprintf("DELETE FROM migrations WHERE name = %s", placeholder(dbType, 1))
+		_, err = db.Exec(del, name)
 		if err != nil {
 			fmt.Println("Failed to delete migration record:", name)
 			db.Close()

--- a/utils/dbox/rollback.go
+++ b/utils/dbox/rollback.go
@@ -45,7 +45,8 @@ func Rollback(dbType, dsn string, pretend bool) {
 		os.Exit(1)
 	}
 
-	_, err = db.Exec("DELETE FROM migrations WHERE name = ?", latest)
+	del := fmt.Sprintf("DELETE FROM migrations WHERE name = %s", placeholder(dbType, 1))
+	_, err = db.Exec(del, latest)
 	if err != nil {
 		fmt.Println("Failed to remove migration record:", latest)
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- add helper to provide driver-specific placeholders
- use helper in migration commands so postgres uses `$1` instead of `?`
- open correct DB type in `refresh` command

## Testing
- `go vet ./...` *(fails: no route to host)*
- `go build ./...` *(fails: no route to host)*