### PR TITLE
Add CQL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Originally built for my own Go backend project, so the file structure might feel a bit custom.
 
-### Built-in support for MySQL, PostgreSQL, and SQLite
+### Built-in support for MySQL, PostgreSQL, SQLite, and CQL (ScyllaDB/Cassandra)
 ---
 
 ## ✨ Features

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,11 @@ go 1.23.0
 toolchain go1.23.8
 
 require (
-	github.com/go-sql-driver/mysql v1.9.1
-	github.com/joho/godotenv v1.5.1
-	github.com/lib/pq v1.10.9
-	modernc.org/sqlite v1.37.0
+        github.com/go-sql-driver/mysql v1.9.1
+        github.com/joho/godotenv v1.5.1
+        github.com/lib/pq v1.10.9
+        github.com/gocql/gocql v1.0.0
+        modernc.org/sqlite v1.37.0
 )
 
 require (

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	}
 
 	if os.Getenv("DB_TYPE") == "" {
-		fmt.Println("You need to set DB_TYPE in your .env file (sqlite, mysql, or postgres)")
+		fmt.Println("You need to set DB_TYPE in your .env file (sqlite, mysql, postgres, or cql)")
 		os.Exit(1)
 	}
 
@@ -99,6 +99,13 @@ func BuildDSN(dbType string) string {
 
 	case "sqlite":
 		return os.Getenv("DB_DATABASE")
+
+	case "cql":
+		return fmt.Sprintf("%s:%s/%s",
+			os.Getenv("DB_HOST"),
+			os.Getenv("DB_PORT"),
+			os.Getenv("DB_NAME"),
+		)
 
 	default:
 		fmt.Println("Unsupported DB_TYPE:", dbType)

--- a/utils/dbox/clean.go
+++ b/utils/dbox/clean.go
@@ -20,6 +20,53 @@ func Clean(dbType, dsn string) {
 	}
 
 	var deleted int
+	if dbType == "cql" {
+		session, err := openCQLSession()
+		if err != nil {
+			fmt.Println("Failed to connect to DB:", err)
+			os.Exit(1)
+		}
+
+		iter := session.Query("SELECT name FROM migrations").Iter()
+		var names []string
+		var n string
+		for iter.Scan(&n) {
+			names = append(names, n)
+		}
+		if err := iter.Close(); err != nil {
+			fmt.Println("Failed to query migrations:", err)
+			session.Close()
+			os.Exit(1)
+		}
+
+		for _, name := range names {
+			path := "db/migrations/" + name
+			_, err := os.Stat(path)
+			if os.IsNotExist(err) {
+				if err := session.Query("DELETE FROM migrations WHERE name = ?", name).Exec(); err != nil {
+					fmt.Println("Failed to delete migration record:", err)
+					session.Close()
+					os.Exit(1)
+				}
+				fmt.Println("Deleted:", name)
+				deleted++
+			}
+		}
+		session.Close()
+
+		if deleted > 0 {
+			word := "records"
+			if deleted == 1 {
+				word = "record"
+			}
+			fmt.Println("\nSuccess!\n")
+			fmt.Printf("Deleted %d migration %s.\n", deleted, word)
+		} else {
+			fmt.Println("\nThere are no migration records to delete. Nothing was changed.")
+		}
+		return
+	}
+
 	db, err := sql.Open(dbType, dsn)
 	if err != nil {
 		fmt.Println("Failed to connect to DB:", err)

--- a/utils/dbox/cql.go
+++ b/utils/dbox/cql.go
@@ -1,0 +1,32 @@
+package dbox
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/gocql/gocql"
+)
+
+func openCQLSession() (*gocql.Session, error) {
+	host := os.Getenv("DB_HOST")
+	portStr := os.Getenv("DB_PORT")
+	port, _ := strconv.Atoi(portStr)
+
+	keyspace := os.Getenv("DB_NAME")
+
+	cluster := gocql.NewCluster(host)
+	if port != 0 {
+		cluster.Port = port
+	}
+	if user := os.Getenv("DB_USER"); user != "" {
+		cluster.Authenticator = gocql.PasswordAuthenticator{
+			Username: user,
+			Password: os.Getenv("DB_PASS"),
+		}
+	}
+	if keyspace != "" {
+		cluster.Keyspace = keyspace
+	}
+
+	return cluster.CreateSession()
+}

--- a/utils/dbox/rollback.go
+++ b/utils/dbox/rollback.go
@@ -4,9 +4,62 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"sort"
 )
 
 func Rollback(dbType, dsn string, pretend bool) {
+	if dbType == "cql" {
+		session, err := openCQLSession()
+		if err != nil {
+			fmt.Println("Failed to connect to DB:", err)
+			os.Exit(1)
+		}
+		defer session.Close()
+
+		var names []string
+		iter := session.Query("SELECT name FROM migrations").Iter()
+		var n string
+		for iter.Scan(&n) {
+			names = append(names, n)
+		}
+		if err := iter.Close(); err != nil {
+			fmt.Println("DB error:", err)
+			os.Exit(1)
+		}
+		if len(names) == 0 {
+			fmt.Println("No migrations to rollback.")
+			return
+		}
+		sort.Strings(names)
+		latest := names[len(names)-1]
+
+		downPath := "db/migrations/" + latest + "/down.sql"
+		downSQL, err := os.ReadFile(downPath)
+		if err != nil {
+			fmt.Println("Failed to read down.sql for", latest)
+			os.Exit(1)
+		}
+
+		if pretend {
+			fmt.Printf("== Pretending rollback: %s\n-- SQL:\n%s\n\n", latest, string(downSQL))
+			return
+		}
+
+		if err := session.Query(string(downSQL)).Exec(); err != nil {
+			fmt.Println("Rollback failed:", latest)
+			fmt.Println("Error:", err)
+			os.Exit(1)
+		}
+
+		if err := session.Query("DELETE FROM migrations WHERE name = ?", latest).Exec(); err != nil {
+			fmt.Println("Failed to remove migration record:", latest)
+			os.Exit(1)
+		}
+
+		fmt.Println("Rolled back:", latest)
+		return
+	}
+
 	db, err := sql.Open(dbType, dsn)
 	if err != nil {
 		fmt.Println("Failed to connect to DB:", err)

--- a/utils/dbox/status.go
+++ b/utils/dbox/status.go
@@ -11,27 +11,47 @@ func Status(dbType, dsn string) {
 
 	applied := make(map[string]bool)
 
-	db, err := sql.Open(dbType, dsn)
-	if err != nil {
-		fmt.Println("Error opening database:", err)
-		os.Exit(1)
-	}
-	defer db.Close()
-
-	rows, err := db.Query("SELECT name FROM migrations")
-	if err != nil {
-		fmt.Println("Failed to fetch applied migrations:", err)
-		os.Exit(1)
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			fmt.Println("Scan error:", err)
+	if dbType == "cql" {
+		session, err := openCQLSession()
+		if err != nil {
+			fmt.Println("Error opening database:", err)
 			os.Exit(1)
 		}
-		applied[name] = true
+
+		iter := session.Query("SELECT name FROM migrations").Iter()
+		var n string
+		for iter.Scan(&n) {
+			applied[n] = true
+		}
+		if err := iter.Close(); err != nil {
+			fmt.Println("Failed to fetch applied migrations:", err)
+			session.Close()
+			os.Exit(1)
+		}
+		session.Close()
+	} else {
+		db, err := sql.Open(dbType, dsn)
+		if err != nil {
+			fmt.Println("Error opening database:", err)
+			os.Exit(1)
+		}
+		defer db.Close()
+
+		rows, err := db.Query("SELECT name FROM migrations")
+		if err != nil {
+			fmt.Println("Failed to fetch applied migrations:", err)
+			os.Exit(1)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var name string
+			if err := rows.Scan(&name); err != nil {
+				fmt.Println("Scan error:", err)
+				os.Exit(1)
+			}
+			applied[name] = true
+		}
 	}
 
 	entries, err := os.ReadDir("db/migrations")


### PR DESCRIPTION
## Summary
- expand DB_TYPE instructions to mention CQL
- support ScyllaDB/Cassandra using gocql
- update README about CQL support
- fix unused gocql imports

## Testing
- `go vet ./...` *(fails: Forbidden when downloading modules)*

------
https://chatgpt.com/codex/tasks/task_b_6841876f9730832d8c0cc85bd1201e7e