### PR TITLE
Add console mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Originally built for my own Go backend project, so the file structure might feel a bit custom.
 
-### Built-in support for MySQL, PostgreSQL, SQLite, and CQL (ScyllaDB/Cassandra)
+### Built-in support for MySQL, PostgreSQL, SQLite, ClickHouse, and CQL (ScyllaDB/Cassandra)
 ---
 
 ## ✨ Features

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,12 @@ go 1.23.0
 toolchain go1.23.8
 
 require (
-        github.com/go-sql-driver/mysql v1.9.1
-        github.com/joho/godotenv v1.5.1
-        github.com/lib/pq v1.10.9
-        github.com/gocql/gocql v1.0.0
-        modernc.org/sqlite v1.37.0
+	github.com/go-sql-driver/mysql v1.9.1
+	github.com/joho/godotenv v1.5.1
+	github.com/lib/pq v1.10.9
+	github.com/ClickHouse/clickhouse-go/v2 v2.11.0
+	github.com/gocql/gocql v1.0.0
+	modernc.org/sqlite v1.37.0
 )
 
 require (

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	}
 
 	if os.Getenv("DB_TYPE") == "" {
-		fmt.Println("You need to set DB_TYPE in your .env file (sqlite, mysql, postgres, or cql)")
+		fmt.Println("You need to set DB_TYPE in your .env file (sqlite, mysql, postgres, clickhouse, or cql)")
 		os.Exit(1)
 	}
 
@@ -33,48 +33,12 @@ func main() {
 	dbType := os.Getenv("DB_TYPE")
 	dsn := BuildDSN(dbType)
 
-	if len(os.Args) < 2 {
-		fmt.Println("No command provided. Type ./dbox help to view all commands.")
-		os.Exit(0)
+	if os.Getenv("DBOX_TYPE") == "console" {
+		runConsole(dbType, dsn)
+		return
 	}
 
-	cmd := os.Args[1]
-
-	switch cmd {
-	case "create", "make":
-		dbox.Create()
-
-	case "migrate", "up":
-		dbox.Migrate(dbType, dsn, pretend)
-
-	case "rollback", "down":
-		dbox.Rollback(dbType, dsn, pretend)
-
-	case "refresh":
-		dbox.Refresh(dbType, dsn, pretend)
-
-	case "status", "stats", "stat":
-		dbox.Status(dbType, dsn)
-
-	case "clean":
-		dbox.Clean(dbType, dsn)
-
-	case "init", "initialize":
-		dbox.Init(dbType, dsn)
-
-	case "help", "?":
-		fmt.Println("DBox - DB Toolbox")
-		fmt.Println("./dbox help - Shows this menu.")
-		fmt.Println("./dbox create [migration_name] - Creates a migration with the specified name.")
-		fmt.Println("./dbox migrate - Run all migrations.\n    --pretend (-p for short) - shows the SQL that would run, but doesn't execute it\n       --dry-run achieves the same result.")
-		fmt.Println("./dbox rollback - Roll the last migration back.")
-		fmt.Println("./dbox refresh - Re-run all migrations from scratch.")
-		fmt.Println("./dbox clean - Deletes all migration registries that don't have a corresponding directory.")
-		fmt.Println("./dbox init - Initializes the main file structure:\n    - Creates db/ and db/migrations")
-	default:
-		fmt.Println("Unknown command:", cmd)
-		fmt.Println("Run ./dbox help for more info.")
-	}
+	runCommand(os.Args[1:], dbType, dsn)
 }
 
 func BuildDSN(dbType string) string {
@@ -100,6 +64,15 @@ func BuildDSN(dbType string) string {
 	case "sqlite":
 		return os.Getenv("DB_DATABASE")
 
+	case "clickhouse":
+		return fmt.Sprintf("clickhouse://%s:%s@%s:%s/%s",
+			os.Getenv("DB_USER"),
+			os.Getenv("DB_PASS"),
+			os.Getenv("DB_HOST"),
+			os.Getenv("DB_PORT"),
+			os.Getenv("DB_NAME"),
+		)
+
 	case "cql":
 		return fmt.Sprintf("%s:%s/%s",
 			os.Getenv("DB_HOST"),
@@ -111,5 +84,97 @@ func BuildDSN(dbType string) string {
 		fmt.Println("Unsupported DB_TYPE:", dbType)
 		os.Exit(1)
 		return ""
+	}
+}
+
+func runConsole(dbType, dsn string) {
+	fmt.Println("DBox Console - type 'exit' to quit")
+	if dbType == "cql" {
+		sess, err := dbox.OpenCQLSession()
+		if err != nil {
+			fmt.Println("Failed to connect to DB:", err)
+			os.Exit(1)
+		}
+		dbox.SharedSession = sess
+		defer func() {
+			sess.Close()
+			dbox.SharedSession = nil
+		}()
+	} else {
+		db, err := sql.Open(dbType, dsn)
+		if err != nil {
+			fmt.Println("Failed to connect to DB:", err)
+			os.Exit(1)
+		}
+		dbox.SharedDB = db
+		defer func() {
+			db.Close()
+			dbox.SharedDB = nil
+		}()
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Print("dbox> ")
+		if !scanner.Scan() {
+			break
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if line == "exit" || line == "quit" {
+			break
+		}
+		args := strings.Fields(line)
+		runCommand(args, dbType, dsn)
+	}
+}
+
+func runCommand(args []string, dbType, dsn string) {
+	if len(args) < 1 {
+		fmt.Println("No command provided. Type help to view all commands.")
+		return
+	}
+
+	pretend := false
+	for _, arg := range args {
+		if arg == "--pretend" || arg == "--dry-run" || arg == "-p" {
+			pretend = true
+			break
+		}
+	}
+
+	os.Args = append([]string{os.Args[0]}, args...)
+
+	cmd := args[0]
+
+	switch cmd {
+	case "create", "make":
+		dbox.Create()
+	case "migrate", "up":
+		dbox.Migrate(dbType, dsn, pretend)
+	case "rollback", "down":
+		dbox.Rollback(dbType, dsn, pretend)
+	case "refresh":
+		dbox.Refresh(dbType, dsn, pretend)
+	case "status", "stats", "stat":
+		dbox.Status(dbType, dsn)
+	case "clean":
+		dbox.Clean(dbType, dsn)
+	case "init", "initialize":
+		dbox.Init(dbType, dsn)
+	case "help", "?":
+		fmt.Println("DBox - DB Toolbox")
+		fmt.Println("./dbox help - Shows this menu.")
+		fmt.Println("./dbox create [migration_name] - Creates a migration with the specified name.")
+		fmt.Println("./dbox migrate - Run all migrations.\n    --pretend (-p for short) - shows the SQL that would run, but doesn't execute it\n    --dry-run achieves the same result.")
+		fmt.Println("./dbox rollback - Roll the last migration back.")
+		fmt.Println("./dbox refresh - Re-run all migrations from scratch.")
+		fmt.Println("./dbox clean - Deletes all migration registries that don't have a corresponding directory.")
+		fmt.Println("./dbox init - Initializes the main file structure:\n    - Creates db/ and db/migrations")
+	default:
+		fmt.Println("Unknown command:", cmd)
+		fmt.Println("Run ./dbox help for more info.")
 	}
 }

--- a/utils/dbox/clean.go
+++ b/utils/dbox/clean.go
@@ -21,7 +21,7 @@ func Clean(dbType, dsn string) {
 
 	var deleted int
 	if dbType == "cql" {
-		session, err := openCQLSession()
+		session, cleanup, err := cqlConn()
 		if err != nil {
 			fmt.Println("Failed to connect to DB:", err)
 			os.Exit(1)
@@ -35,7 +35,7 @@ func Clean(dbType, dsn string) {
 		}
 		if err := iter.Close(); err != nil {
 			fmt.Println("Failed to query migrations:", err)
-			session.Close()
+			cleanup()
 			os.Exit(1)
 		}
 
@@ -45,14 +45,14 @@ func Clean(dbType, dsn string) {
 			if os.IsNotExist(err) {
 				if err := session.Query("DELETE FROM migrations WHERE name = ?", name).Exec(); err != nil {
 					fmt.Println("Failed to delete migration record:", err)
-					session.Close()
+					cleanup()
 					os.Exit(1)
 				}
 				fmt.Println("Deleted:", name)
 				deleted++
 			}
 		}
-		session.Close()
+		cleanup()
 
 		if deleted > 0 {
 			word := "records"
@@ -67,12 +67,12 @@ func Clean(dbType, dsn string) {
 		return
 	}
 
-	db, err := sql.Open(dbType, dsn)
+	db, cleanup, err := sqlConn(dbType, dsn)
 	if err != nil {
 		fmt.Println("Failed to connect to DB:", err)
 		os.Exit(1)
 	}
-	defer db.Close()
+	defer cleanup()
 
 	// STEP 1: fetch all migration names into a slice
 	rows, err := db.Query("SELECT name FROM migrations")

--- a/utils/dbox/cql.go
+++ b/utils/dbox/cql.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gocql/gocql"
 )
 
-func openCQLSession() (*gocql.Session, error) {
+func OpenCQLSession() (*gocql.Session, error) {
 	host := os.Getenv("DB_HOST")
 	portStr := os.Getenv("DB_PORT")
 	port, _ := strconv.Atoi(portStr)

--- a/utils/dbox/helpers.go
+++ b/utils/dbox/helpers.go
@@ -1,6 +1,30 @@
 package dbox
 
-import "fmt"
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/gocql/gocql"
+)
+
+var SharedDB *sql.DB
+var SharedSession *gocql.Session
+
+func sqlConn(dbType, dsn string) (*sql.DB, func(), error) {
+	if SharedDB != nil {
+		return SharedDB, func() {}, nil
+	}
+	db, err := sql.Open(dbType, dsn)
+	return db, func() { db.Close() }, err
+}
+
+func cqlConn() (*gocql.Session, func(), error) {
+	if SharedSession != nil {
+		return SharedSession, func() {}, nil
+	}
+	sess, err := OpenCQLSession()
+	return sess, func() { sess.Close() }, err
+}
 
 func placeholder(dbType string, n int) string {
 	if dbType == "postgres" {

--- a/utils/dbox/init.go
+++ b/utils/dbox/init.go
@@ -3,6 +3,7 @@ package dbox
 import (
 	"database/sql"
 	"fmt"
+	_ "github.com/ClickHouse/clickhouse-go/v2"
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 	"os"
@@ -42,12 +43,12 @@ func Init(dbType, dsn string) {
 	input = strings.ToLower(input)
 	if input == "yes" {
 		if dbType == "cql" {
-			session, err := openCQLSession()
+			session, cleanup, err := cqlConn()
 			if err != nil {
 				fmt.Println("Failed to connect to db:", err)
 				os.Exit(1)
 			}
-			defer session.Close()
+			defer cleanup()
 
 			if err := session.Query(`CREATE TABLE IF NOT EXISTS migrations (name text PRIMARY KEY)`).Exec(); err != nil {
 				fmt.Println("Failed to create migration table:", err)
@@ -55,18 +56,22 @@ func Init(dbType, dsn string) {
 			}
 			fmt.Println("Migration records table created.")
 		} else {
-			db, err := sql.Open(dbType, dsn)
+			db, cleanup, err := sqlConn(dbType, dsn)
 			if err != nil {
 				fmt.Println("Failed to connect to db:", err)
 				os.Exit(1)
 			}
-			defer db.Close()
+			defer cleanup()
 
-			_, err = db.Exec(`
-                                CREATE TABLE IF NOT EXISTS migrations (
-                                    name VARCHAR(255) PRIMARY KEY
-                                )
-                        `)
+			query := `
+                               CREATE TABLE IF NOT EXISTS migrations (
+                                   name VARCHAR(255) PRIMARY KEY
+                               )
+                       `
+			if dbType == "clickhouse" {
+				query = "CREATE TABLE IF NOT EXISTS migrations (name String) ENGINE = MergeTree() ORDER BY name"
+			}
+			_, err = db.Exec(query)
 			if err != nil {
 				fmt.Println("Failed to create migration table:", err)
 				os.Exit(1)

--- a/utils/dbox/migrate.go
+++ b/utils/dbox/migrate.go
@@ -14,12 +14,12 @@ func Migrate(dbType, dsn string, pretend bool) {
 		os.Mkdir("db", 0755)
 	}
 	if dbType == "cql" {
-		session, err := openCQLSession()
+		session, cleanup, err := cqlConn()
 		if err != nil {
 			fmt.Println("Failed to connect to DB:", err)
 			os.Exit(1)
 		}
-		defer session.Close()
+		defer cleanup()
 
 		if err := session.Query(`CREATE TABLE IF NOT EXISTS migrations (name text PRIMARY KEY)`).Exec(); err != nil {
 			fmt.Println("Failed to create migrations table:", err)
@@ -78,17 +78,21 @@ func Migrate(dbType, dsn string, pretend bool) {
 		return
 	}
 
-	db, err := sql.Open(dbType, dsn)
+	db, cleanup, err := sqlConn(dbType, dsn)
 	if err != nil {
 		fmt.Println("Failed to connect to DB:", err)
 	}
-	defer db.Close()
+	defer cleanup()
 
-	_, err = db.Exec(`
-			CREATE TABLE IF NOT EXISTS migrations (
-			    name TEXT PRIMARY KEY
-			)
-		`)
+	createTable := `
+                       CREATE TABLE IF NOT EXISTS migrations (
+                           name TEXT PRIMARY KEY
+                       )
+               `
+	if dbType == "clickhouse" {
+		createTable = `CREATE TABLE IF NOT EXISTS migrations (name String) ENGINE = MergeTree() ORDER BY name`
+	}
+	_, err = db.Exec(createTable)
 	if err != nil {
 		fmt.Println("Failed to create migrations table:", err)
 		os.Exit(1)

--- a/utils/dbox/refresh.go
+++ b/utils/dbox/refresh.go
@@ -21,11 +21,12 @@ func Refresh(dbType, dsn string, pretend bool) {
 	}
 
 	if dbType == "cql" {
-		session, err := openCQLSession()
+		session, cleanup, err := cqlConn()
 		if err != nil {
 			fmt.Println("Failed to connect to DB:", err)
 			os.Exit(1)
 		}
+		defer cleanup()
 
 		iter := session.Query("SELECT name FROM migrations").Iter()
 		var names []string
@@ -35,15 +36,13 @@ func Refresh(dbType, dsn string, pretend bool) {
 		}
 		if err := iter.Close(); err != nil {
 			fmt.Println("Failed to fetch migrations:", err)
-			session.Close()
 			os.Exit(1)
 		}
-		session.Close()
 
 		sort.Sort(sort.Reverse(sort.StringSlice(names)))
 
 		for _, name := range names {
-			sess, err := openCQLSession()
+			sess, cqlCleanup, err := cqlConn()
 			if err != nil {
 				fmt.Println("Failed to connect to DB:", err)
 				os.Exit(1)
@@ -52,21 +51,21 @@ func Refresh(dbType, dsn string, pretend bool) {
 			sqlBytes, err := os.ReadFile(downPath)
 			if err != nil {
 				fmt.Println("Failed to read:", downPath)
-				sess.Close()
+				cqlCleanup()
 				os.Exit(1)
 			}
 			if err := sess.Query(string(sqlBytes)).Exec(); err != nil {
 				fmt.Println("Failed to rollback:", name)
 				fmt.Println("Error:", err)
-				sess.Close()
+				cqlCleanup()
 				os.Exit(1)
 			}
 			if err := sess.Query("DELETE FROM migrations WHERE name = ?", name).Exec(); err != nil {
 				fmt.Println("Failed to delete migration record:", name)
-				sess.Close()
+				cqlCleanup()
 				os.Exit(1)
 			}
-			sess.Close()
+			cqlCleanup()
 			fmt.Println("Rolled back:", name)
 		}
 
@@ -74,11 +73,12 @@ func Refresh(dbType, dsn string, pretend bool) {
 		return
 	}
 
-	db, err := sql.Open(dbType, dsn)
+	db, cleanup, err := sqlConn(dbType, dsn)
 	if err != nil {
 		fmt.Println("Failed to connect to DB:", err)
 		os.Exit(1)
 	}
+	defer cleanup()
 
 	rows, err := db.Query("SELECT name FROM migrations ORDER BY name DESC")
 	if err != nil {
@@ -98,10 +98,9 @@ func Refresh(dbType, dsn string, pretend bool) {
 	}
 
 	rows.Close()
-	db.Close()
 
 	for _, name := range names {
-		db, err := sql.Open(dbType, dsn)
+		db, c, err := sqlConn(dbType, dsn)
 		if err != nil {
 			fmt.Println("Failed to connect to DB:", err)
 			os.Exit(1)
@@ -118,7 +117,7 @@ func Refresh(dbType, dsn string, pretend bool) {
 		if err != nil {
 			fmt.Println("Failed to rollback:", name)
 			fmt.Println("Error:", err)
-			db.Close()
+			c()
 			os.Exit(1)
 		}
 
@@ -126,11 +125,11 @@ func Refresh(dbType, dsn string, pretend bool) {
 		_, err = db.Exec(del, name)
 		if err != nil {
 			fmt.Println("Failed to delete migration record:", name)
-			db.Close()
+			c()
 			os.Exit(1)
 		}
 
-		db.Close()
+		c()
 		fmt.Println("Rolled back:", name)
 	}
 	Migrate(dbType, dsn, pretend)

--- a/utils/dbox/rollback.go
+++ b/utils/dbox/rollback.go
@@ -9,12 +9,12 @@ import (
 
 func Rollback(dbType, dsn string, pretend bool) {
 	if dbType == "cql" {
-		session, err := openCQLSession()
+		session, cleanup, err := cqlConn()
 		if err != nil {
 			fmt.Println("Failed to connect to DB:", err)
 			os.Exit(1)
 		}
-		defer session.Close()
+		defer cleanup()
 
 		var names []string
 		iter := session.Query("SELECT name FROM migrations").Iter()
@@ -60,12 +60,12 @@ func Rollback(dbType, dsn string, pretend bool) {
 		return
 	}
 
-	db, err := sql.Open(dbType, dsn)
+	db, cleanup, err := sqlConn(dbType, dsn)
 	if err != nil {
 		fmt.Println("Failed to connect to DB:", err)
 		os.Exit(1)
 	}
-	defer db.Close()
+	defer cleanup()
 
 	var latest string
 	err = db.QueryRow("SELECT name FROM migrations ORDER BY name DESC LIMIT 1").Scan(&latest)

--- a/utils/dbox/status.go
+++ b/utils/dbox/status.go
@@ -12,11 +12,12 @@ func Status(dbType, dsn string) {
 	applied := make(map[string]bool)
 
 	if dbType == "cql" {
-		session, err := openCQLSession()
+		session, cleanup, err := cqlConn()
 		if err != nil {
 			fmt.Println("Error opening database:", err)
 			os.Exit(1)
 		}
+		defer cleanup()
 
 		iter := session.Query("SELECT name FROM migrations").Iter()
 		var n string
@@ -25,17 +26,15 @@ func Status(dbType, dsn string) {
 		}
 		if err := iter.Close(); err != nil {
 			fmt.Println("Failed to fetch applied migrations:", err)
-			session.Close()
 			os.Exit(1)
 		}
-		session.Close()
 	} else {
-		db, err := sql.Open(dbType, dsn)
+		db, cleanup, err := sqlConn(dbType, dsn)
 		if err != nil {
 			fmt.Println("Error opening database:", err)
 			os.Exit(1)
 		}
-		defer db.Close()
+		defer cleanup()
 
 		rows, err := db.Query("SELECT name FROM migrations")
 		if err != nil {


### PR DESCRIPTION
## Summary
- support interactive console mode via `DBOX_TYPE=console`
- maintain one DB connection for console sessions
- centralize DB sharing helpers
- update ClickHouse driver references

## Testing
- `go mod tidy` *(fails: forbidden)*
- `go vet ./...` *(fails: missing go.sum entry and network access)*
- `go build ./...` *(fails: missing go.sum entry and network access)*

------
https://chatgpt.com/codex/tasks/task_b_684ef20586ac832db51ae7feb2402bac